### PR TITLE
chore: Update GitHub Actions to use latest versions of actions for Do…

### DIFF
--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -27,10 +27,10 @@ jobs:
         working-directory: ./docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: yarn
@@ -43,13 +43,13 @@ jobs:
         run: yarn build
       
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./docs/build
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2 
+        uses: actions/deploy-pages@v4 


### PR DESCRIPTION
…cusaurus deployment

- Upgraded actions/checkout, actions/setup-node, actions/configure-pages, actions/upload-pages-artifact, and actions/deploy-pages to their respective v4 versions in the Docusaurus deployment workflow.