### PR TITLE
chore: Update Docusaurus deployment workflow and documentation structure

### DIFF
--- a/.github/workflows/docusaurus-deploy.yml
+++ b/.github/workflows/docusaurus-deploy.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
+      - name: Copy screenshots to static directory
+        run: npm run prepare-screenshots
+      
       - name: Build
         run: npm run build
       

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -18,3 +18,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Keep the screenshots directory README
+!/static/screenshots/README.md

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -41,13 +41,13 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           // Please change this to your repo.
           editUrl:
-            'https://github.com/StarFleetCPTN/GoMFT/tree/main/documentation',
+            'https://github.com/StarFleetCPTN/GoMFT/tree/main/docs',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/StarFleetCPTN/GoMFT/tree/main/documentation',
+            'https://github.com/StarFleetCPTN/GoMFT/tree/main/docs',
         },
         theme: {
           customCss: './src/css/custom.css',

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "deploy-gh-pages": "GIT_USER=StarFleetCPTN USE_SSH=true yarn deploy"
+    "deploy-gh-pages": "GIT_USER=StarFleetCPTN USE_SSH=true yarn deploy",
+    "prepare-screenshots": "node -e \"const fs = require('fs'); if (!fs.existsSync('./static/screenshots')) { fs.mkdirSync('./static/screenshots', { recursive: true }); fs.readdirSync('../screenshots').forEach(file => { if (!fs.existsSync('./static/screenshots/' + file)) { fs.copyFileSync('../screenshots/' + file, './static/screenshots/' + file); } }); }\""
   },
   "dependencies": {
     "@docusaurus/core": "3.7.0",

--- a/docs/static/screenshots/README.md
+++ b/docs/static/screenshots/README.md
@@ -1,0 +1,7 @@
+# Screenshots directory
+
+This directory contains copies of the screenshots from the main repository root. These are used in the documentation site.
+
+The contents of this directory are automatically updated by the `prepare-screenshots` script in the package.json file.
+
+Do not manually add files to this directory as they will be overwritten by the scripts. 


### PR DESCRIPTION
- Added a step to copy screenshots to the static directory during deployment.
- Updated .gitignore to keep the README file in the screenshots directory.
- Added a new README file in the screenshots directory to explain its purpose and usage.
- Introduced a new npm script to prepare screenshots for the documentation site.